### PR TITLE
Upgrade moke-kit + harden public/private auth assembly

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -5,8 +5,11 @@
 | platform (this repo) | `v1.0.5-0.20260811085843-60e104db6db7` (#221) | Subscribe cancel, DocumentBase CAS, CORS allowlist, TLS/mTLS split, request-path auth fail-closed |
 | game | platform commit that depends on the kit version above | See [game#18](https://github.com/moke-game/game/issues/18) |
 
+Auth startup fail-closed: platform `ProdAuthGuardModule` (inside `AuthMiddlewareModule` / `AuthAllModule`) covers public gRPC + gateway when those modules are imported. Binder-level enforcement for “forgot middleware entirely” is tracked in kit [#224](https://github.com/GStones/moke-kit/pull/224).
+
 Tracking:
 
 - kit plan: https://github.com/GStones/moke-kit/issues/223
 - kit hardening PR (startup binder): https://github.com/GStones/moke-kit/pull/224
 - platform: https://github.com/moke-game/platform/issues/23
+- game: https://github.com/moke-game/game/issues/18

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,0 +1,12 @@
+# Compatibility
+
+| Consumer | Minimum moke-kit | Notes |
+|----------|------------------|-------|
+| platform (this repo) | `v1.0.5-0.20260811085843-60e104db6db7` (#221) | Subscribe cancel, DocumentBase CAS, CORS allowlist, TLS/mTLS split, request-path auth fail-closed |
+| game | platform commit that depends on the kit version above | See [game#18](https://github.com/moke-game/game/issues/18) |
+
+Tracking:
+
+- kit plan: https://github.com/GStones/moke-kit/issues/223
+- kit hardening PR (startup binder): https://github.com/GStones/moke-kit/pull/224
+- platform: https://github.com/moke-game/platform/issues/23

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -5,7 +5,7 @@
 | platform (this repo) | `v1.0.5-0.20260811085843-60e104db6db7` (#221) | Subscribe cancel, DocumentBase CAS, CORS allowlist, TLS/mTLS split, request-path auth fail-closed |
 | game | platform commit that depends on the kit version above | See [game#18](https://github.com/moke-game/game/issues/18) |
 
-Auth startup fail-closed: platform `ProdAuthGuardModule` (inside `AuthMiddlewareModule` / `AuthAllModule`) covers public gRPC + gateway when those modules are imported. Binder-level enforcement for “forgot middleware entirely” is tracked in kit [#224](https://github.com/GStones/moke-kit/pull/224).
+Auth startup fail-closed: platform `ProdAuthGuardModule` (inside `AuthMiddlewareModule` / `AuthAllModule` / `PrivateServiceAuthModule`) covers public gRPC + gateway when those modules are imported. Binder-level enforcement for “forgot middleware entirely” is in kit [#224](https://github.com/GStones/moke-kit/pull/224) (merged on kit main). `cmd/auth` uses `AuthAllModule`; private-only `cmd/analytics` uses `PrivateServiceAuthModule` so binder `HasAuth` is satisfied while handlers keep `utility.WithoutAuth`.
 
 Tracking:
 

--- a/cmd/analytics/service/main.go
+++ b/cmd/analytics/service/main.go
@@ -3,11 +3,15 @@ package main
 import (
 	"github.com/gstones/moke-kit/fxmain"
 
-	"github.com/moke-game/platform/services/analytics/pkg/module"
+	analytics "github.com/moke-game/platform/services/analytics/pkg/module"
+	auth "github.com/moke-game/platform/services/auth/pkg/module"
 )
 
 func main() {
 	fxmain.Main(
-		module.AnalyticsModule,
+		analytics.AnalyticsModule,
+		// Analytics embeds WithoutAuth; pass-through middleware satisfies kit
+		// binder prod checks (#224+) without calling ValidateToken.
+		auth.PrivateServiceAuthModule,
 	)
 }

--- a/cmd/auth/service/main.go
+++ b/cmd/auth/service/main.go
@@ -10,6 +10,9 @@ import (
 func main() {
 	fxmain.Main(
 		ofx.RedisCacheModule,
-		module.AuthModule,
+		// AuthAllModule = AuthService (WithoutAuth) + AuthMiddleware.
+		// Middleware satisfies kit binder prod checks (#224+) while login RPCs
+		// remain reachable via utility.WithoutAuth on the auth service.
+		module.AuthAllModule,
 	)
 }

--- a/cmd/matchmaking/service/main.go
+++ b/cmd/matchmaking/service/main.go
@@ -3,11 +3,14 @@ package main
 import (
 	"github.com/gstones/moke-kit/fxmain"
 
+	auth "github.com/moke-game/platform/services/auth/pkg/module"
 	mm "github.com/moke-game/platform/services/matchmaking/pkg/module"
 )
 
 func main() {
 	fxmain.Main(
+		// MatchService is client-facing (public); require AuthMiddleware.
+		auth.AuthMiddlewareModule,
 		mm.MatchmakingModule,
 	)
 }

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.1
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3
-	github.com/gstones/moke-kit v1.0.5-0.20250414125136-0f0537f47883
+	github.com/gstones/moke-kit v1.0.5-0.20260811085843-60e104db6db7
 	github.com/gstones/zinx v1.2.7-0.20240617071724-88bd884d8d08
 	github.com/json-iterator/go v1.1.12
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -135,8 +135,8 @@ github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.1 h1:KcFzXwzM/kGhIRHvc8jdix
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.1/go.mod h1:qOchhhIlmRcqk/O9uCo/puJlyo07YINaIqdZfZG3Jkc=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 h1:5ZPtiqj0JL5oKWmcsq4VMaAW5ukBEgSGXEN89zeH1Jo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3/go.mod h1:ndYquD05frm2vACXE1nsccT4oJzjhw2arTS2cpUD1PI=
-github.com/gstones/moke-kit v1.0.5-0.20250414125136-0f0537f47883 h1:spAnuLc/C7AIaMxbdUb2NGfJM87RxzPCjm1dGg56on4=
-github.com/gstones/moke-kit v1.0.5-0.20250414125136-0f0537f47883/go.mod h1:jJsse+hpKKiP3t0i3lutXQjq3tmobqe59mVDUvysjvQ=
+github.com/gstones/moke-kit v1.0.5-0.20260811085843-60e104db6db7 h1:0NIOJm4M6x/sFMB6eTI3ahjFzGhtjQk4c+vPiQJz+6A=
+github.com/gstones/moke-kit v1.0.5-0.20260811085843-60e104db6db7/go.mod h1:jJsse+hpKKiP3t0i3lutXQjq3tmobqe59mVDUvysjvQ=
 github.com/gstones/zinx v1.2.7-0.20240617071724-88bd884d8d08 h1:YjrnGjuIRVs2t0MjMs4DFQox9GH/4jlOELMRVD5d+xg=
 github.com/gstones/zinx v1.2.7-0.20240617071724-88bd884d8d08/go.mod h1:tgm/iZBMyKKZj4totfeu4+PMzSLb4JH8pnGdcG3ql+8=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/services/auth/README.md
+++ b/services/auth/README.md
@@ -35,6 +35,9 @@ token认证服务器，提供用户认证服务。[为什么需要token认证?](
 
 ### Fail-closed (prod)
 
-`AuthMiddlewareModule` / `AuthAllModule` run a startup check: if `DEPLOYMENT` is prod and any **public** gRPC service is registered without `AuthMiddleware`, the process refuses to start.
+`AuthMiddlewareModule` / `AuthAllModule` run a startup check: if `DEPLOYMENT` is prod and any **public** gRPC or gateway service is registered without `AuthMiddleware`, the process refuses to start.
 
-With moke-kit ≥ #221, missing middleware also fails closed **per request** in production.
+**Limitation:** the guard is an `fx.Invoke` inside those auth modules. A main that forgets to import them will not run the guard. Mitigation until kit binder check lands ([#224](https://github.com/GStones/moke-kit/pull/224)):
+
+- moke-kit ≥ #221 fails closed **per request** in production when middleware is nil
+- every public-facing `cmd/*/service` should import `AuthMiddlewareModule` or `AuthAllModule`

--- a/services/auth/README.md
+++ b/services/auth/README.md
@@ -20,7 +20,7 @@ token认证服务器，提供用户认证服务。[为什么需要token认证?](
 | `AuthClientModule` | `AuthServiceClient` | Call ValidateToken / Authenticate without hosting auth |
 | `AuthMiddlewareModule` | Client + `AuthCheckModule` (`AuthMiddleware`) + prod guard | Any process hosting **public** gRPC/HTTP |
 | `AuthAllModule` | Service + client + middleware + prod guard | Aggregate/monolith (`cmd/platform`, local game) and dedicated `cmd/auth` |
-| `PrivateServiceAuthModule` | Pass-through `AuthMiddleware` + prod guard | Private-only processes (`cmd/analytics`) for kit #224+ binder |
+| `PrivateServiceAuthModule` | Pass-through `AuthMiddleware` + prod guard | Private-only processes (`cmd/analytics`) for kit #224+ binder. **Never** combine with public/gateway modules — prod guard rejects that. |
 | `SupabaseMiddlewareModule` | Alternate JWT middleware | Supabase auth path |
 
 | Surface | Rule |

--- a/services/auth/README.md
+++ b/services/auth/README.md
@@ -16,10 +16,11 @@ token认证服务器，提供用户认证服务。[为什么需要token认证?](
 
 | Module | Provides | When to use |
 |--------|----------|-------------|
-| `AuthModule` | Auth gRPC service + settings | Dedicated auth microservice (`cmd/auth`) |
+| `AuthModule` | Auth gRPC service + settings | Rare; prefer `AuthAllModule` for `cmd/auth` |
 | `AuthClientModule` | `AuthServiceClient` | Call ValidateToken / Authenticate without hosting auth |
 | `AuthMiddlewareModule` | Client + `AuthCheckModule` (`AuthMiddleware`) + prod guard | Any process hosting **public** gRPC/HTTP |
-| `AuthAllModule` | Service + client + middleware + prod guard | Aggregate/monolith (`cmd/platform`, local game) |
+| `AuthAllModule` | Service + client + middleware + prod guard | Aggregate/monolith (`cmd/platform`, local game) and dedicated `cmd/auth` |
+| `PrivateServiceAuthModule` | Pass-through `AuthMiddleware` + prod guard | Private-only processes (`cmd/analytics`) for kit #224+ binder |
 | `SupabaseMiddlewareModule` | Alternate JWT middleware | Supabase auth path |
 
 | Surface | Rule |
@@ -35,9 +36,10 @@ token认证服务器，提供用户认证服务。[为什么需要token认证?](
 
 ### Fail-closed (prod)
 
-`AuthMiddlewareModule` / `AuthAllModule` run a startup check: if `DEPLOYMENT` is prod and any **public** gRPC or gateway service is registered without `AuthMiddleware`, the process refuses to start.
+`AuthMiddlewareModule` / `AuthAllModule` / `PrivateServiceAuthModule` run a startup check: if `DEPLOYMENT` is prod and any **public** gRPC or gateway service is registered without `AuthMiddleware`, the process refuses to start.
 
-**Limitation:** the guard is an `fx.Invoke` inside those auth modules. A main that forgets to import them will not run the guard. Mitigation until kit binder check lands ([#224](https://github.com/GStones/moke-kit/pull/224)):
+**Limitation:** the platform guard is an `fx.Invoke` inside those auth modules. A main that forgets them will not run the guard. Mitigations:
 
 - moke-kit ≥ #221 fails closed **per request** in production when middleware is nil
-- every public-facing `cmd/*/service` should import `AuthMiddlewareModule` or `AuthAllModule`
+- kit [#224](https://github.com/GStones/moke-kit/pull/224) binder fails closed at startup when grpc/gateway lack middleware (on kit main; bump when ready)
+- `cmd/auth` → `AuthAllModule`; private-only `cmd/analytics` → `PrivateServiceAuthModule`

--- a/services/auth/README.md
+++ b/services/auth/README.md
@@ -12,5 +12,29 @@ token认证服务器，提供用户认证服务。[为什么需要token认证?](
 
 ![validate](../../draws/auth-validate.drawio.png)
 
+## Assembly matrix
 
- 
+| Module | Provides | When to use |
+|--------|----------|-------------|
+| `AuthModule` | Auth gRPC service + settings | Dedicated auth microservice (`cmd/auth`) |
+| `AuthClientModule` | `AuthServiceClient` | Call ValidateToken / Authenticate without hosting auth |
+| `AuthMiddlewareModule` | Client + `AuthCheckModule` (`AuthMiddleware`) + prod guard | Any process hosting **public** gRPC/HTTP |
+| `AuthAllModule` | Service + client + middleware + prod guard | Aggregate/monolith (`cmd/platform`, local game) |
+| `SupabaseMiddlewareModule` | Alternate JWT middleware | Supabase auth path |
+
+| Surface | Rule |
+|---------|------|
+| Public `*Service` | No `utility.WithoutAuth`; process **must** import `AuthMiddlewareModule` (or `AuthAllModule`); handlers read `UIDContextKey` |
+| Private `*PrivateService` | Embed `utility.WithoutAuth`; internal network only |
+| Auth / Analytics | Embed `utility.WithoutAuth` by design |
+
+### Public vs private
+
+- **Public**: profile, knapsack, mail, chat, leaderboard, party, buddy, matchmaking, and any game template public API.
+- **Private**: `*PrivateService` counterparts (profile/knapsack/mail/chat/leaderboard private) plus auth & analytics.
+
+### Fail-closed (prod)
+
+`AuthMiddlewareModule` / `AuthAllModule` run a startup check: if `DEPLOYMENT` is prod and any **public** gRPC service is registered without `AuthMiddleware`, the process refuses to start.
+
+With moke-kit ≥ #221, missing middleware also fails closed **per request** in production.

--- a/services/auth/README.md
+++ b/services/auth/README.md
@@ -20,7 +20,7 @@ token认证服务器，提供用户认证服务。[为什么需要token认证?](
 | `AuthClientModule` | `AuthServiceClient` | Call ValidateToken / Authenticate without hosting auth |
 | `AuthMiddlewareModule` | Client + `AuthCheckModule` (`AuthMiddleware`) + prod guard | Any process hosting **public** gRPC/HTTP |
 | `AuthAllModule` | Service + client + middleware + prod guard | Aggregate/monolith (`cmd/platform`, local game) and dedicated `cmd/auth` |
-| `PrivateServiceAuthModule` | Pass-through `AuthMiddleware` + prod guard | Private-only processes (`cmd/analytics`) for kit #224+ binder. **Never** combine with public/gateway modules — prod guard rejects that. |
+| `PrivateServiceAuthModule` | Pass-through `AuthMiddleware` + prod guard | Private-only processes (`cmd/analytics`) for kit #224+ binder. Prod guard rejects combining with **public** gRPC/gateway (no `WithoutAuth`). Private gateway (e.g. analytics) is OK. |
 | `SupabaseMiddlewareModule` | Alternate JWT middleware | Supabase auth path |
 
 | Surface | Rule |

--- a/services/auth/pkg/afx/passthrough_middleware.go
+++ b/services/auth/pkg/afx/passthrough_middleware.go
@@ -1,0 +1,28 @@
+package afx
+
+import (
+	"context"
+
+	"github.com/gstones/moke-kit/server/pkg/sfx"
+	"github.com/gstones/moke-kit/utility"
+	"go.uber.org/fx"
+)
+
+// passThroughAuthor satisfies siface.IAuthMiddleware without validating tokens.
+// Use only for processes that exclusively host utility.WithoutAuth services
+// (e.g. analytics) so kit binder prod checks (#224+) see AuthMiddleware != nil.
+type passThroughAuthor struct{}
+
+func (p *passThroughAuthor) Auth(ctx context.Context) (context.Context, error) {
+	return context.WithValue(ctx, utility.WithOutTag, true), nil
+}
+
+func (p *passThroughAuthor) AddUnAuthMethod(string) {}
+
+// PassThroughAuthModule provides a no-op AuthMiddleware for private-only processes.
+var PassThroughAuthModule = fx.Provide(
+	func() (out sfx.AuthMiddlewareResult, err error) {
+		out.AuthMiddleware = &passThroughAuthor{}
+		return
+	},
+)

--- a/services/auth/pkg/afx/prod_auth_guard.go
+++ b/services/auth/pkg/afx/prod_auth_guard.go
@@ -24,14 +24,23 @@ func hasPublicGrpc(grpc sfx.GrpcServiceParams) bool {
 	return false
 }
 
+func hasPublicGateway(gateway sfx.GatewayServiceParams) bool {
+	for _, svc := range gateway.GatewayServices {
+		if _, private := svc.(authFuncOverrider); !private {
+			return true
+		}
+	}
+	return false
+}
+
 // CheckProdPublicAuthFailClosed fails process startup in production when any
 // public gRPC or gateway service is registered without real AuthMiddleware.
 //
-// Private services that embed utility.WithoutAuth are exempt; they are expected
-// to stay on internal networks only.
+// Private services that embed utility.WithoutAuth are exempt (gRPC and gateway);
+// they are expected to stay on internal networks only.
 //
 // Pass-through middleware (PrivateServiceAuthModule) is only allowed when every
-// registered gRPC service is private and no gateway is present.
+// registered gRPC/gateway service is private (implements AuthFuncOverride).
 //
 // Note: this Invoke is wired into AuthMiddlewareModule / AuthAllModule /
 // PrivateServiceAuthModule. If a main forgets those modules entirely, this check
@@ -48,10 +57,10 @@ func CheckProdPublicAuthFailClosed(
 	}
 
 	publicGrpc := hasPublicGrpc(grpc)
-	hasGateway := len(gateway.GatewayServices) > 0
+	publicGateway := hasPublicGateway(gateway)
 
 	if _, passThrough := auth.AuthMiddleware.(*passThroughAuthor); passThrough {
-		if publicGrpc || hasGateway {
+		if publicGrpc || publicGateway {
 			return fmt.Errorf(
 				"prod: PrivateServiceAuthModule (pass-through) cannot be used with public gRPC or gateway services",
 			)
@@ -73,10 +82,16 @@ func CheckProdPublicAuthFailClosed(
 			)
 		}
 	}
-	if hasGateway {
-		return fmt.Errorf(
-			"prod: gateway service registered without AuthMiddleware (fail-closed)",
-		)
+	if publicGateway {
+		for _, svc := range gateway.GatewayServices {
+			if _, private := svc.(authFuncOverrider); private {
+				continue
+			}
+			return fmt.Errorf(
+				"prod: public gateway service %T registered without AuthMiddleware (fail-closed)",
+				svc,
+			)
+		}
 	}
 	return nil
 }

--- a/services/auth/pkg/afx/prod_auth_guard.go
+++ b/services/auth/pkg/afx/prod_auth_guard.go
@@ -1,0 +1,47 @@
+package afx
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gstones/moke-kit/fxmain/pkg/mfx"
+	"github.com/gstones/moke-kit/server/pkg/sfx"
+	"github.com/gstones/moke-kit/utility"
+	"go.uber.org/fx"
+)
+
+// authFuncOverrider matches grpc-ecosystem AuthFuncOverride (e.g. utility.WithoutAuth).
+type authFuncOverrider interface {
+	AuthFuncOverride(ctx context.Context, fullMethodName string) (context.Context, error)
+}
+
+// CheckProdPublicAuthFailClosed fails process startup in production when any
+// public gRPC service is registered without AuthMiddleware.
+//
+// Private services that embed utility.WithoutAuth are exempt; they are expected
+// to stay on internal networks only.
+func CheckProdPublicAuthFailClosed(
+	app mfx.AppParams,
+	auth sfx.AuthMiddlewareParams,
+	grpc sfx.GrpcServiceParams,
+) error {
+	if !utility.ParseDeployments(app.Deployment).IsProd() {
+		return nil
+	}
+	if auth.AuthMiddleware != nil {
+		return nil
+	}
+	for _, svc := range grpc.GrpcServices {
+		if _, private := svc.(authFuncOverrider); private {
+			continue
+		}
+		return fmt.Errorf(
+			"prod: public gRPC service %T registered without AuthMiddleware (fail-closed)",
+			svc,
+		)
+	}
+	return nil
+}
+
+// ProdAuthGuardModule runs the production public-auth startup check.
+var ProdAuthGuardModule = fx.Invoke(CheckProdPublicAuthFailClosed)

--- a/services/auth/pkg/afx/prod_auth_guard.go
+++ b/services/auth/pkg/afx/prod_auth_guard.go
@@ -15,15 +15,28 @@ type authFuncOverrider interface {
 	AuthFuncOverride(ctx context.Context, fullMethodName string) (context.Context, error)
 }
 
+func hasPublicGrpc(grpc sfx.GrpcServiceParams) bool {
+	for _, svc := range grpc.GrpcServices {
+		if _, private := svc.(authFuncOverrider); !private {
+			return true
+		}
+	}
+	return false
+}
+
 // CheckProdPublicAuthFailClosed fails process startup in production when any
-// public gRPC or gateway service is registered without AuthMiddleware.
+// public gRPC or gateway service is registered without real AuthMiddleware.
 //
 // Private services that embed utility.WithoutAuth are exempt; they are expected
 // to stay on internal networks only.
 //
-// Note: this Invoke is wired into AuthMiddlewareModule / AuthAllModule. If a
-// main forgets those modules entirely, this check does not run — rely on
-// moke-kit #221 request-path fail-closed, or kit #224 binder startup check.
+// Pass-through middleware (PrivateServiceAuthModule) is only allowed when every
+// registered gRPC service is private and no gateway is present.
+//
+// Note: this Invoke is wired into AuthMiddlewareModule / AuthAllModule /
+// PrivateServiceAuthModule. If a main forgets those modules entirely, this check
+// does not run — rely on moke-kit #221 request-path fail-closed, or kit #224
+// binder startup check.
 func CheckProdPublicAuthFailClosed(
 	app mfx.AppParams,
 	auth sfx.AuthMiddlewareParams,
@@ -33,19 +46,34 @@ func CheckProdPublicAuthFailClosed(
 	if !utility.ParseDeployments(app.Deployment).IsProd() {
 		return nil
 	}
+
+	publicGrpc := hasPublicGrpc(grpc)
+	hasGateway := len(gateway.GatewayServices) > 0
+
+	if _, passThrough := auth.AuthMiddleware.(*passThroughAuthor); passThrough {
+		if publicGrpc || hasGateway {
+			return fmt.Errorf(
+				"prod: PrivateServiceAuthModule (pass-through) cannot be used with public gRPC or gateway services",
+			)
+		}
+		return nil
+	}
+
 	if auth.AuthMiddleware != nil {
 		return nil
 	}
-	for _, svc := range grpc.GrpcServices {
-		if _, private := svc.(authFuncOverrider); private {
-			continue
+	if publicGrpc {
+		for _, svc := range grpc.GrpcServices {
+			if _, private := svc.(authFuncOverrider); private {
+				continue
+			}
+			return fmt.Errorf(
+				"prod: public gRPC service %T registered without AuthMiddleware (fail-closed)",
+				svc,
+			)
 		}
-		return fmt.Errorf(
-			"prod: public gRPC service %T registered without AuthMiddleware (fail-closed)",
-			svc,
-		)
 	}
-	if len(gateway.GatewayServices) > 0 {
+	if hasGateway {
 		return fmt.Errorf(
 			"prod: gateway service registered without AuthMiddleware (fail-closed)",
 		)

--- a/services/auth/pkg/afx/prod_auth_guard.go
+++ b/services/auth/pkg/afx/prod_auth_guard.go
@@ -16,14 +16,19 @@ type authFuncOverrider interface {
 }
 
 // CheckProdPublicAuthFailClosed fails process startup in production when any
-// public gRPC service is registered without AuthMiddleware.
+// public gRPC or gateway service is registered without AuthMiddleware.
 //
 // Private services that embed utility.WithoutAuth are exempt; they are expected
 // to stay on internal networks only.
+//
+// Note: this Invoke is wired into AuthMiddlewareModule / AuthAllModule. If a
+// main forgets those modules entirely, this check does not run — rely on
+// moke-kit #221 request-path fail-closed, or kit #224 binder startup check.
 func CheckProdPublicAuthFailClosed(
 	app mfx.AppParams,
 	auth sfx.AuthMiddlewareParams,
 	grpc sfx.GrpcServiceParams,
+	gateway sfx.GatewayServiceParams,
 ) error {
 	if !utility.ParseDeployments(app.Deployment).IsProd() {
 		return nil
@@ -38,6 +43,11 @@ func CheckProdPublicAuthFailClosed(
 		return fmt.Errorf(
 			"prod: public gRPC service %T registered without AuthMiddleware (fail-closed)",
 			svc,
+		)
+	}
+	if len(gateway.GatewayServices) > 0 {
+		return fmt.Errorf(
+			"prod: gateway service registered without AuthMiddleware (fail-closed)",
 		)
 	}
 	return nil

--- a/services/auth/pkg/afx/prod_auth_guard_test.go
+++ b/services/auth/pkg/afx/prod_auth_guard_test.go
@@ -89,6 +89,26 @@ func TestCheckProdPublicAuthFailClosed(t *testing.T) {
 			auth:    sfx.AuthMiddlewareParams{AuthMiddleware: stubAuth{}},
 			gateway: sfx.GatewayServiceParams{GatewayServices: []siface.IGatewayService{gatewaySvc{}}},
 		},
+		{
+			name:   "prod pass-through with private-only ok",
+			deploy: "prod",
+			auth:   sfx.AuthMiddlewareParams{AuthMiddleware: &passThroughAuthor{}},
+			grpc:   sfx.GrpcServiceParams{GrpcServices: []siface.IGrpcService{privateSvc{}}},
+		},
+		{
+			name:    "prod pass-through with public fails",
+			deploy:  "prod",
+			auth:    sfx.AuthMiddlewareParams{AuthMiddleware: &passThroughAuthor{}},
+			grpc:    sfx.GrpcServiceParams{GrpcServices: []siface.IGrpcService{publicSvc{}}},
+			wantErr: true,
+		},
+		{
+			name:    "prod pass-through with gateway fails",
+			deploy:  "prod",
+			auth:    sfx.AuthMiddlewareParams{AuthMiddleware: &passThroughAuthor{}},
+			gateway: sfx.GatewayServiceParams{GatewayServices: []siface.IGatewayService{gatewaySvc{}}},
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range cases {

--- a/services/auth/pkg/afx/prod_auth_guard_test.go
+++ b/services/auth/pkg/afx/prod_auth_guard_test.go
@@ -1,0 +1,94 @@
+package afx
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gstones/moke-kit/fxmain/pkg/mfx"
+	"github.com/gstones/moke-kit/server/pkg/sfx"
+	"github.com/gstones/moke-kit/server/siface"
+)
+
+type publicSvc struct{}
+
+func (publicSvc) RegisterWithGrpcServer(siface.IGrpcServer) error { return nil }
+
+type privateSvc struct {
+	utilityWithoutAuth
+}
+
+type utilityWithoutAuth struct{}
+
+func (utilityWithoutAuth) AuthFuncOverride(ctx context.Context, _ string) (context.Context, error) {
+	return ctx, nil
+}
+
+func (privateSvc) RegisterWithGrpcServer(siface.IGrpcServer) error { return nil }
+
+type stubAuth struct{}
+
+func (stubAuth) Auth(ctx context.Context) (context.Context, error) { return ctx, nil }
+
+func (stubAuth) AddUnAuthMethod(string) {}
+
+func TestCheckProdPublicAuthFailClosed(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		deploy  string
+		auth    sfx.AuthMiddlewareParams
+		grpc    sfx.GrpcServiceParams
+		wantErr bool
+	}{
+		{
+			name:   "non-prod allows missing middleware",
+			deploy: "local",
+			grpc:   sfx.GrpcServiceParams{GrpcServices: []siface.IGrpcService{publicSvc{}}},
+		},
+		{
+			name:   "prod private-only ok without middleware",
+			deploy: "prod",
+			grpc:   sfx.GrpcServiceParams{GrpcServices: []siface.IGrpcService{privateSvc{}}},
+		},
+		{
+			name:    "prod public without middleware fails",
+			deploy:  "prod",
+			grpc:    sfx.GrpcServiceParams{GrpcServices: []siface.IGrpcService{publicSvc{}}},
+			wantErr: true,
+		},
+		{
+			name:   "prod public with middleware ok",
+			deploy: "prod",
+			auth:   sfx.AuthMiddlewareParams{AuthMiddleware: stubAuth{}},
+			grpc:   sfx.GrpcServiceParams{GrpcServices: []siface.IGrpcService{publicSvc{}}},
+		},
+		{
+			name:   "prod mixed services require middleware",
+			deploy: "prod",
+			grpc: sfx.GrpcServiceParams{GrpcServices: []siface.IGrpcService{
+				privateSvc{},
+				publicSvc{},
+			}},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := CheckProdPublicAuthFailClosed(
+				mfx.AppParams{Deployment: tc.deploy},
+				tc.auth,
+				tc.grpc,
+			)
+			if tc.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/services/auth/pkg/afx/prod_auth_guard_test.go
+++ b/services/auth/pkg/afx/prod_auth_guard_test.go
@@ -25,6 +25,10 @@ func (utilityWithoutAuth) AuthFuncOverride(ctx context.Context, _ string) (conte
 
 func (privateSvc) RegisterWithGrpcServer(siface.IGrpcServer) error { return nil }
 
+type gatewaySvc struct{}
+
+func (gatewaySvc) RegisterWithGatewayServer(siface.IGatewayServer) error { return nil }
+
 type stubAuth struct{}
 
 func (stubAuth) Auth(ctx context.Context) (context.Context, error) { return ctx, nil }
@@ -39,6 +43,7 @@ func TestCheckProdPublicAuthFailClosed(t *testing.T) {
 		deploy  string
 		auth    sfx.AuthMiddlewareParams
 		grpc    sfx.GrpcServiceParams
+		gateway sfx.GatewayServiceParams
 		wantErr bool
 	}{
 		{
@@ -72,6 +77,18 @@ func TestCheckProdPublicAuthFailClosed(t *testing.T) {
 			}},
 			wantErr: true,
 		},
+		{
+			name:    "prod gateway without middleware fails",
+			deploy:  "prod",
+			gateway: sfx.GatewayServiceParams{GatewayServices: []siface.IGatewayService{gatewaySvc{}}},
+			wantErr: true,
+		},
+		{
+			name:    "prod gateway with middleware ok",
+			deploy:  "prod",
+			auth:    sfx.AuthMiddlewareParams{AuthMiddleware: stubAuth{}},
+			gateway: sfx.GatewayServiceParams{GatewayServices: []siface.IGatewayService{gatewaySvc{}}},
+		},
 	}
 
 	for _, tc := range cases {
@@ -82,6 +99,7 @@ func TestCheckProdPublicAuthFailClosed(t *testing.T) {
 				mfx.AppParams{Deployment: tc.deploy},
 				tc.auth,
 				tc.grpc,
+				tc.gateway,
 			)
 			if tc.wantErr && err == nil {
 				t.Fatal("expected error, got nil")

--- a/services/auth/pkg/afx/prod_auth_guard_test.go
+++ b/services/auth/pkg/afx/prod_auth_guard_test.go
@@ -25,9 +25,15 @@ func (utilityWithoutAuth) AuthFuncOverride(ctx context.Context, _ string) (conte
 
 func (privateSvc) RegisterWithGrpcServer(siface.IGrpcServer) error { return nil }
 
-type gatewaySvc struct{}
+type publicGatewaySvc struct{}
 
-func (gatewaySvc) RegisterWithGatewayServer(siface.IGatewayServer) error { return nil }
+func (publicGatewaySvc) RegisterWithGatewayServer(siface.IGatewayServer) error { return nil }
+
+type privateGatewaySvc struct {
+	utilityWithoutAuth
+}
+
+func (privateGatewaySvc) RegisterWithGatewayServer(siface.IGatewayServer) error { return nil }
 
 type stubAuth struct{}
 
@@ -78,22 +84,34 @@ func TestCheckProdPublicAuthFailClosed(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "prod gateway without middleware fails",
+			name:    "prod public gateway without middleware fails",
 			deploy:  "prod",
-			gateway: sfx.GatewayServiceParams{GatewayServices: []siface.IGatewayService{gatewaySvc{}}},
+			gateway: sfx.GatewayServiceParams{GatewayServices: []siface.IGatewayService{publicGatewaySvc{}}},
 			wantErr: true,
 		},
 		{
-			name:    "prod gateway with middleware ok",
+			name:    "prod private gateway without middleware ok",
 			deploy:  "prod",
-			auth:    sfx.AuthMiddlewareParams{AuthMiddleware: stubAuth{}},
-			gateway: sfx.GatewayServiceParams{GatewayServices: []siface.IGatewayService{gatewaySvc{}}},
+			gateway: sfx.GatewayServiceParams{GatewayServices: []siface.IGatewayService{privateGatewaySvc{}}},
 		},
 		{
-			name:   "prod pass-through with private-only ok",
+			name:    "prod public gateway with middleware ok",
+			deploy:  "prod",
+			auth:    sfx.AuthMiddlewareParams{AuthMiddleware: stubAuth{}},
+			gateway: sfx.GatewayServiceParams{GatewayServices: []siface.IGatewayService{publicGatewaySvc{}}},
+		},
+		{
+			name:   "prod pass-through with private grpc ok",
 			deploy: "prod",
 			auth:   sfx.AuthMiddlewareParams{AuthMiddleware: &passThroughAuthor{}},
 			grpc:   sfx.GrpcServiceParams{GrpcServices: []siface.IGrpcService{privateSvc{}}},
+		},
+		{
+			name:    "prod pass-through with private gateway ok (analytics)",
+			deploy:  "prod",
+			auth:    sfx.AuthMiddlewareParams{AuthMiddleware: &passThroughAuthor{}},
+			grpc:    sfx.GrpcServiceParams{GrpcServices: []siface.IGrpcService{privateSvc{}}},
+			gateway: sfx.GatewayServiceParams{GatewayServices: []siface.IGatewayService{privateGatewaySvc{}}},
 		},
 		{
 			name:    "prod pass-through with public fails",
@@ -103,10 +121,10 @@ func TestCheckProdPublicAuthFailClosed(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "prod pass-through with gateway fails",
+			name:    "prod pass-through with public gateway fails",
 			deploy:  "prod",
 			auth:    sfx.AuthMiddlewareParams{AuthMiddleware: &passThroughAuthor{}},
-			gateway: sfx.GatewayServiceParams{GatewayServices: []siface.IGatewayService{gatewaySvc{}}},
+			gateway: sfx.GatewayServiceParams{GatewayServices: []siface.IGatewayService{publicGatewaySvc{}}},
 			wantErr: true,
 		},
 	}

--- a/services/auth/pkg/module/module.go
+++ b/services/auth/pkg/module/module.go
@@ -7,27 +7,32 @@ import (
 	"github.com/moke-game/platform/services/auth/pkg/afx"
 )
 
-// AuthModule Provides auth service
+// AuthModule provides the Auth gRPC service (Authenticate / ValidateToken / …).
+// Use this for the dedicated auth microservice (cmd/auth). The auth service itself
+// embeds utility.WithoutAuth so login flows remain reachable without a prior token.
 var AuthModule = fx.Module("auth",
 	afx.SettingsModule,
 	internal.ServiceModule,
 )
 
-// AuthClientModule Provides auth client for grpc
+// AuthClientModule provides an AuthServiceClient for calling AuthService.
 var AuthClientModule = fx.Module("auth_client",
 	afx.SettingsModule,
 	afx.AuthClientModule,
 )
 
-// AuthMiddlewareModule Provides auth middleware for grpc
-// if import this module, every grpc unary/stream will auth by {mfx.AuthCheckModule}
+// AuthMiddlewareModule provides AuthServiceClient + AuthCheckModule middleware.
+// Import this in every process that hosts public gRPC/HTTP services.
+// Private *PrivateService handlers should embed utility.WithoutAuth and stay
+// on internal networks only.
 var AuthMiddlewareModule = fx.Module("auth_middleware",
 	afx.SettingsModule,
 	afx.AuthClientModule,
 	afx.AuthCheckModule,
+	afx.ProdAuthGuardModule,
 )
 
-// SupabaseMiddlewareModule Provides supabase middleware for grpc
+// SupabaseMiddlewareModule provides supabase middleware for grpc.
 // if import this module, every grpc unary/stream will auth by supabase auth
 // https://supabase.com/docs/guides/auth
 var SupabaseMiddlewareModule = fx.Module("supabase_middleware",
@@ -35,10 +40,13 @@ var SupabaseMiddlewareModule = fx.Module("supabase_middleware",
 	afx.SupabaseCheckModule,
 )
 
-// AuthAllModule  Provides client, service and middleware for auth
+// AuthAllModule provides auth service + client + middleware for aggregate/monolith
+// processes (cmd/platform, local game aggregate). Equivalent to AuthModule plus
+// AuthMiddlewareModule without duplicating settings providers.
 var AuthAllModule = fx.Module("auth_all",
+	afx.SettingsModule,
 	internal.ServiceModule,
 	afx.AuthClientModule,
-	//afx.AuthCheckModule,
-	afx.SettingsModule,
+	afx.AuthCheckModule,
+	afx.ProdAuthGuardModule,
 )

--- a/services/auth/pkg/module/module.go
+++ b/services/auth/pkg/module/module.go
@@ -8,8 +8,8 @@ import (
 )
 
 // AuthModule provides the Auth gRPC service (Authenticate / ValidateToken / …).
-// Use this for the dedicated auth microservice (cmd/auth). The auth service itself
-// embeds utility.WithoutAuth so login flows remain reachable without a prior token.
+// Prefer AuthAllModule for cmd/auth so kit binder prod checks (#224+) see middleware.
+// The auth service embeds utility.WithoutAuth so login flows remain reachable.
 var AuthModule = fx.Module("auth",
 	afx.SettingsModule,
 	internal.ServiceModule,
@@ -41,12 +41,21 @@ var SupabaseMiddlewareModule = fx.Module("supabase_middleware",
 )
 
 // AuthAllModule provides auth service + client + middleware for aggregate/monolith
-// processes (cmd/platform, local game aggregate). Equivalent to AuthModule plus
+// processes (cmd/platform, cmd/auth, local game). Equivalent to AuthModule plus
 // AuthMiddlewareModule without duplicating settings providers.
+// AuthService embeds utility.WithoutAuth so Authenticate/ValidateToken stay public.
 var AuthAllModule = fx.Module("auth_all",
 	afx.SettingsModule,
 	internal.ServiceModule,
 	afx.AuthClientModule,
 	afx.AuthCheckModule,
+	afx.ProdAuthGuardModule,
+)
+
+// PrivateServiceAuthModule provides a pass-through AuthMiddleware for processes
+// that only host utility.WithoutAuth services (e.g. analytics). Satisfies kit
+// binder prod checks (#224+) without requiring a real AuthService client.
+var PrivateServiceAuthModule = fx.Module("private_service_auth",
+	afx.PassThroughAuthModule,
 	afx.ProdAuthGuardModule,
 )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Implements [platform#23](https://github.com/moke-game/platform/issues/23) P0 against moke-kit #221, with prep for kit #224 binder checks.

### Changes
- Bump `moke-kit` to #221 (`60e104d`)
- Restore `AuthCheckModule` in `AuthAllModule`
- Document assembly matrix + fail-closed limits
- Prod startup fail-closed for **public** gRPC/gateway (private `WithoutAuth` exempt, including private gateways like analytics)
- Pass-through (`PrivateServiceAuthModule`) rejected with **public** services only
- `cmd/matchmaking` → `AuthMiddlewareModule`
- `cmd/auth` → `AuthAllModule`
- `cmd/analytics` → `PrivateServiceAuthModule`
- `COMPATIBILITY.md`

### Test plan
- [x] `go test ./services/auth/...` (private gateway + pass-through cases)
- [x] `go build` auth/analytics/platform
- [ ] CI green

Related: [game#19](https://github.com/moke-game/game/pull/19)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-398a3149-3eb1-4944-b716-74b5ecd93293?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-398a3149-3eb1-4944-b716-74b5ecd93293&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

