### PR TITLE
docs: refresh COMPATIBILITY after #27 / kit#228 / game#22

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -2,14 +2,15 @@
 
 | Consumer | Minimum moke-kit | Notes |
 |----------|------------------|-------|
-| platform (this repo) | `v1.0.5-0.20260811094419-bcdfe55515cd` (#224) | #221 Subscribe/CAS/CORS/TLS/Auth + #224 binder startup fail-closed (prod auth + CORS) |
-| game | platform `main` at/after [#25](https://github.com/moke-game/platform/pull/25) (`fcdebd60…`) | [game#20](https://github.com/moke-game/game/pull/20) |
+| platform (this repo) | `v1.0.5-0.20260811094419-bcdfe55515cd` (#224); tip [`#228`](https://github.com/GStones/moke-kit/pull/228) `acb9f313d7fd` on kit `main` | #221 Subscribe/CAS/CORS/TLS/Auth + #224 binder fail-closed; #228 CAS/StopServing/CI |
+| game | platform `main` at/after [#27](https://github.com/moke-game/platform/pull/27) (`40241b23…`) | [game#22](https://github.com/moke-game/game/pull/22) |
 
 Auth startup fail-closed:
 
 - Platform `ProdAuthGuardModule` (inside `AuthMiddlewareModule` / `AuthAllModule` / `PrivateServiceAuthModule`) covers public gRPC + gateway when those modules are imported.
 - Kit binder (`ValidateSecurityConfig`, #224) fails closed when grpc/gateway lack middleware or prod CORS allowlist is empty.
 - `cmd/auth` uses `AuthAllModule`; private-only `cmd/analytics` uses `PrivateServiceAuthModule`.
+- `JwtTokenExpire<=0` omits JWT `exp` and stores the redis auth token with no TTL.
 
 Messaging topic conventions: [docs/messaging.md](docs/messaging.md).
 
@@ -17,10 +18,13 @@ Merged:
 
 - kit hardening: https://github.com/GStones/moke-kit/pull/224
 - kit create-game sync: https://github.com/GStones/moke-kit/pull/226
+- kit CAS/StopServing/CI: https://github.com/GStones/moke-kit/pull/228
 - platform P0: https://github.com/moke-game/platform/pull/24
 - platform P1: https://github.com/moke-game/platform/pull/25
+- platform jwt/v5 + CAS/chat tests: https://github.com/moke-game/platform/pull/27
 - game P0/P1: https://github.com/moke-game/game/pull/19
 - game P2 bump: https://github.com/moke-game/game/pull/20
+- game CI + platform pin: https://github.com/moke-game/game/pull/22
 
 Tracking plans:
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -3,7 +3,7 @@
 | Consumer | Minimum moke-kit | Notes |
 |----------|------------------|-------|
 | platform (this repo) | `v1.0.5-0.20260811094419-bcdfe55515cd` (#224) | #221 Subscribe/CAS/CORS/TLS/Auth + #224 binder startup fail-closed (prod auth + CORS) |
-| game | platform commit that depends on the kit version above | See [game#18](https://github.com/moke-game/game/issues/18) |
+| game | platform `main` at/after [#25](https://github.com/moke-game/platform/pull/25) (`fcdebd60…`) | [game#20](https://github.com/moke-game/game/pull/20) |
 
 Auth startup fail-closed:
 
@@ -13,9 +13,17 @@ Auth startup fail-closed:
 
 Messaging topic conventions: [docs/messaging.md](docs/messaging.md).
 
-Tracking:
+Merged:
 
-- kit plan: https://github.com/GStones/moke-kit/issues/223
 - kit hardening: https://github.com/GStones/moke-kit/pull/224
+- kit create-game sync: https://github.com/GStones/moke-kit/pull/226
+- platform P0: https://github.com/moke-game/platform/pull/24
+- platform P1: https://github.com/moke-game/platform/pull/25
+- game P0/P1: https://github.com/moke-game/game/pull/19
+- game P2 bump: https://github.com/moke-game/game/pull/20
+
+Tracking plans:
+
+- kit: https://github.com/GStones/moke-kit/issues/223
 - platform: https://github.com/moke-game/platform/issues/23
 - game: https://github.com/moke-game/game/issues/18


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Post-merge docs refresh after [#27](https://github.com/moke-game/platform/pull/27), [kit#228](https://github.com/GStones/moke-kit/pull/228), and [game#22](https://github.com/moke-game/game/pull/22).

### Changes
- Point game consumers at platform `main` merge `40241b23…` (#27)
- Record kit tip `#228` and jwt/v5 / `JwtTokenExpire<=0` notes
- Extend merged-PR list

### Test plan
- [x] Docs-only

Related: [kit#227](https://github.com/GStones/moke-kit/pull/227), [game post-merge pin](https://github.com/moke-game/game/compare/main...cursor/post-merge-compat-pin-3293)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-398a3149-3eb1-4944-b716-74b5ecd93293?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-398a3149-3eb1-4944-b716-74b5ecd93293&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

