### PR TITLE
feat(auth): bump kit #228, reject prod non-expiring JWT, gate buf-push

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -17,9 +17,9 @@ jobs:
         with:
           against: "https://github.com/${{ github.repository }}.git#branch=main,ref=HEAD~1"
 
-      # BSR push requires a valid BUF_TOKEN secret. Keep non-blocking until rotated.
+      # Skip when BUF_TOKEN is unset; fail hard when present but invalid.
       - name: Push module to BSR
-        continue-on-error: true
+        if: ${{ secrets.BUF_TOKEN != '' }}
         uses: bufbuild/buf-push-action@v1
         with:
           buf_token: ${{ secrets.BUF_TOKEN }}

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -2,15 +2,15 @@
 
 | Consumer | Minimum moke-kit | Notes |
 |----------|------------------|-------|
-| platform (this repo) | `v1.0.5-0.20260811094419-bcdfe55515cd` (#224); tip [`#228`](https://github.com/GStones/moke-kit/pull/228) `acb9f313d7fd` on kit `main` | #221 Subscribe/CAS/CORS/TLS/Auth + #224 binder fail-closed; #228 CAS/StopServing/CI |
-| game | platform `main` at/after [#27](https://github.com/moke-game/platform/pull/27) (`40241b23…`) | [game#22](https://github.com/moke-game/game/pull/22) |
+| platform (this repo) | `v1.0.5-0.20260812022140-acb9f313d7fd` ([#228](https://github.com/GStones/moke-kit/pull/228)) | #221 Subscribe/CAS/CORS/TLS/Auth + #224 binder fail-closed + #228 CAS/StopServing/CI |
+| game | platform `main` at/after this pin bump | kit `#228` + jwt expire prod guard |
 
 Auth startup fail-closed:
 
 - Platform `ProdAuthGuardModule` (inside `AuthMiddlewareModule` / `AuthAllModule` / `PrivateServiceAuthModule`) covers public gRPC + gateway when those modules are imported.
 - Kit binder (`ValidateSecurityConfig`, #224) fails closed when grpc/gateway lack middleware or prod CORS allowlist is empty.
 - `cmd/auth` uses `AuthAllModule`; private-only `cmd/analytics` uses `PrivateServiceAuthModule`.
-- `JwtTokenExpire<=0` omits JWT `exp` and stores the redis auth token with no TTL.
+- `JwtTokenExpire<=0` omits JWT `exp` and Redis TTL only outside prod; prod requires `JWT_TOKEN_EXPIRE > 0`.
 
 Messaging topic conventions: [docs/messaging.md](docs/messaging.md).
 
@@ -25,6 +25,7 @@ Merged:
 - game P0/P1: https://github.com/moke-game/game/pull/19
 - game P2 bump: https://github.com/moke-game/game/pull/20
 - game CI + platform pin: https://github.com/moke-game/game/pull/22
+- game post-merge pin: https://github.com/moke-game/game/pull/23
 
 Tracking plans:
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.1
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0
-	github.com/gstones/moke-kit v1.0.5-0.20260811094419-bcdfe55515cd
+	github.com/gstones/moke-kit v1.0.5-0.20260812022140-acb9f313d7fd
 	github.com/gstones/zinx v1.2.7-0.20240617071724-88bd884d8d08
 	github.com/json-iterator/go v1.1.12
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -139,8 +139,8 @@ github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.1 h1:KcFzXwzM/kGhIRHvc8jdix
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.1/go.mod h1:qOchhhIlmRcqk/O9uCo/puJlyo07YINaIqdZfZG3Jkc=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 h1:HWRh5R2+9EifMyIHV7ZV+MIZqgz+PMpZ14Jynv3O2Zs=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0/go.mod h1:JfhWUomR1baixubs02l85lZYYOm7LV6om4ceouMv45c=
-github.com/gstones/moke-kit v1.0.5-0.20260811094419-bcdfe55515cd h1:Wjoql7CGC37RqOd7cuvWaIfY3+nLQggihqoZVRLnju0=
-github.com/gstones/moke-kit v1.0.5-0.20260811094419-bcdfe55515cd/go.mod h1:v/VZdvZ2wSit8B4plZBJ8nzBJFlZNQ1X6vI0jdfQJFU=
+github.com/gstones/moke-kit v1.0.5-0.20260812022140-acb9f313d7fd h1:0lklTFcnbZt771O4WEanbdyqomi4b6fWMt/A04dEYMo=
+github.com/gstones/moke-kit v1.0.5-0.20260812022140-acb9f313d7fd/go.mod h1:v/VZdvZ2wSit8B4plZBJ8nzBJFlZNQ1X6vI0jdfQJFU=
 github.com/gstones/zinx v1.2.7-0.20240617071724-88bd884d8d08 h1:YjrnGjuIRVs2t0MjMs4DFQox9GH/4jlOELMRVD5d+xg=
 github.com/gstones/zinx v1.2.7-0.20240617071724-88bd884d8d08/go.mod h1:tgm/iZBMyKKZj4totfeu4+PMzSLb4JH8pnGdcG3ql+8=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/services/auth/pkg/afx/auth_settings.go
+++ b/services/auth/pkg/afx/auth_settings.go
@@ -1,6 +1,9 @@
 package afx
 
 import (
+	"fmt"
+
+	"github.com/gstones/moke-kit/fxmain/pkg/mfx"
 	"github.com/gstones/moke-kit/utility"
 	"go.uber.org/fx"
 )
@@ -22,6 +25,7 @@ type AuthSettingsResult struct {
 	JwtTokenSecret string `name:"JwtTokenSecret" default:"" envconfig:"JWT_TOKEN_SECRET"`
 	// JwtTokenExpire token lifetime in hours.
 	// <=0 omits JWT exp and stores the redis auth token with no TTL (non-expiring).
+	// Forbidden when DEPLOYMENT is prod.
 	JwtTokenExpire int32 `name:"JwtTokenExpire" default:"12" envconfig:"JWT_TOKEN_EXPIRE"`
 }
 
@@ -30,9 +34,22 @@ func (g *AuthSettingsResult) LoadFromEnv() (err error) {
 	return
 }
 
+func validateJwtExpire(deployment string, expire int32) error {
+	if expire > 0 {
+		return nil
+	}
+	if utility.ParseDeployments(deployment).IsProd() {
+		return fmt.Errorf("prod: JWT_TOKEN_EXPIRE must be > 0 (non-expiring tokens forbidden)")
+	}
+	return nil
+}
+
 var SettingsModule = fx.Provide(
-	func() (out AuthSettingsResult, err error) {
-		err = out.LoadFromEnv()
+	func(app mfx.AppParams) (out AuthSettingsResult, err error) {
+		if err = out.LoadFromEnv(); err != nil {
+			return
+		}
+		err = validateJwtExpire(app.Deployment, out.JwtTokenExpire)
 		return
 	},
 )

--- a/services/auth/pkg/afx/auth_settings_test.go
+++ b/services/auth/pkg/afx/auth_settings_test.go
@@ -1,0 +1,30 @@
+package afx
+
+import "testing"
+
+func TestValidateJwtExpire(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name       string
+		deployment string
+		expire     int32
+		wantErr    bool
+	}{
+		{name: "prod positive", deployment: "prod", expire: 12},
+		{name: "prod zero", deployment: "prod", expire: 0, wantErr: true},
+		{name: "prod negative", deployment: "prod_gcp", expire: -1, wantErr: true},
+		{name: "local zero ok", deployment: "local", expire: 0},
+		{name: "dev zero ok", deployment: "dev", expire: 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateJwtExpire(tc.deployment, tc.expire)
+			if tc.wantErr && err == nil {
+				t.Fatal("expected error")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Continues [platform#23](https://github.com/moke-game/platform/issues/23) after #27 / #26.

### Changes
- Bump `moke-kit` to `#228` tip `v1.0.5-0.20260812022140-acb9f313d7fd`
- Prod fail-closed: `JWT_TOKEN_EXPIRE` must be `> 0` (local/dev may still omit `exp`)
- `buf-push`: skip when `BUF_TOKEN` unset (remove `continue-on-error`)
- Refresh `COMPATIBILITY.md`

### Depends on
None (kit `#228` already on `main`).

### Test plan
- [x] `go test ./services/auth/pkg/afx/ -count=1`
- [ ] CI green

Related: [game follow-up](https://github.com/moke-game/game/compare/main...cursor/issue-18-kit228-modules-3293)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-398a3149-3eb1-4944-b716-74b5ecd93293?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-398a3149-3eb1-4944-b716-74b5ecd93293&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

