### PR TITLE
fix(ci): restore buf-push by gating BUF_TOKEN via env

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -6,6 +6,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -18,8 +20,9 @@ jobs:
           against: "https://github.com/${{ github.repository }}.git#branch=main,ref=HEAD~1"
 
       # Skip when BUF_TOKEN is unset; fail hard when present but invalid.
+      # secrets cannot be referenced in if:; map to env first.
       - name: Push module to BSR
-        if: ${{ secrets.BUF_TOKEN != '' }}
+        if: ${{ env.BUF_TOKEN != '' }}
         uses: bufbuild/buf-push-action@v1
         with:
           buf_token: ${{ secrets.BUF_TOKEN }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Main-branch runs of `.github/workflows/push.yaml` have failed at parse time since [#28](https://github.com/moke-game/platform/pull/28) (latest: [run 31570891803](https://github.com/moke-game/platform/actions/runs/31570891803)) with:

`Unrecognized named-value: 'secrets'. Located at position 1 within expression: secrets.BUF_TOKEN != ''`

GitHub Actions does not allow the `secrets` context in `if:` expressions. Restore the intended skip-if-unset / fail-if-invalid BSR push without `continue-on-error` (which would hide an invalid token).

### Changes
- Map `BUF_TOKEN` to a job-level env var
- Gate the BSR push step on `env.BUF_TOKEN != ''`
- Keep fail-hard behavior when the token is present but invalid

### Test plan
- [x] Workflow no longer references `secrets` inside `if:`
- [x] `actionlint` clean on `.github/workflows/push.yaml`
- [ ] Go CI on this PR (unrelated: pre-existing `govulncheck` stdlib findings; Go workflow was not changed)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48e00318-2b64-44d9-8bdb-8206b53d0b71?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48e00318-2b64-44d9-8bdb-8206b53d0b71&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

