### PR TITLE
fix(ci): keep BUF_TOKEN off job env for buf-breaking

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -7,7 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
+      HAS_BUF_TOKEN: ${{ secrets.BUF_TOKEN != '' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -20,9 +20,9 @@ jobs:
           against: "https://github.com/${{ github.repository }}.git#branch=main,ref=HEAD~1"
 
       # Skip when BUF_TOKEN is unset; fail hard when present but invalid.
-      # secrets cannot be referenced in if:; map to env first.
+      # secrets cannot be referenced in if:; use a boolean env, not the token itself.
       - name: Push module to BSR
-        if: ${{ env.BUF_TOKEN != '' }}
+        if: ${{ env.HAS_BUF_TOKEN == 'true' }}
         uses: bufbuild/buf-push-action@v1
         with:
           buf_token: ${{ secrets.BUF_TOKEN }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
After [#33](https://github.com/moke-game/platform/pull/33), `buf-push` parses but [run 32225961560](https://github.com/moke-game/platform/actions/runs/32225961560) failed because job-level `BUF_TOKEN` leaked into `bufbuild/buf-breaking-action@v1`:

> Failure: the BUF_TOKEN environment variable is not valid for buf.build. Set BUF_TOKEN to a valid Buf API token, or unset it.

The BSR push step never ran.

### Changes
- Replace job-level `BUF_TOKEN` with boolean `HAS_BUF_TOKEN: ${{ secrets.BUF_TOKEN != '' }}`
- Gate the BSR push on `env.HAS_BUF_TOKEN == 'true'` (still no `secrets` in `if:`)
- Pass `buf_token: ${{ secrets.BUF_TOKEN }}` only on the push step so `buf-breaking` does not see the token
- Keep fail-hard behavior when the token is present but invalid (no `continue-on-error`)

### Test plan
- [x] Job env does not set `BUF_TOKEN`
- [x] Workflow does not reference `secrets` inside `if:`
- [x] `actionlint` clean on `.github/workflows/push.yaml`
- [ ] Go CI on this PR (unrelated if it fails on existing `govulncheck`; Go workflow was not changed)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48e00318-2b64-44d9-8bdb-8206b53d0b71?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48e00318-2b64-44d9-8bdb-8206b53d0b71&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

